### PR TITLE
ModuleFoundError: No module named 'sugar3'

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,6 @@
+[flake8]
+
+# E402 module level import not at top of file
+# gi.require_version() is required before later imports
+
+ignore = E402

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+*~
+*.pyc
+*.pyo
+dist/
+locale/

--- a/NEWS
+++ b/NEWS
@@ -1,0 +1,11 @@
+7
+
+* Add missing repository field (Walter Bender)
+* Fix Python GI API warnings (James Cameron)
+* Minor changes for flake8 (James Cameron)
+* Create README.md (Dave Crossland)
+* Add sample gitignore (Rahul Bothra)
+* Port to Python 3 (Rahul Bothra)
+* Add .flake8 (Ayush Nawal)
+* Change repository field (Ibiam Chihurumnaya)
+* Add NEWS (Ibiam Chihurumnaya)

--- a/README.md
+++ b/README.md
@@ -1,0 +1,8 @@
+## Sugar Hello World Example
+
+This is an example Sugar Desktop Activity, that follows the "Hello World" tradition of being a small and simple demonstration of a complete program for a system. 
+
+## Other Examples
+
+* https://github.com/erilyth/Hello-World-Python_Sugar
+* [Your example here?]

--- a/activity.py
+++ b/activity.py
@@ -24,11 +24,8 @@ from gettext import gettext as _
 
 from sugar3.activity import activity
 from sugar3.graphics.toolbarbox import ToolbarBox
-from sugar3.activity.widgets import ActivityButton
-from sugar3.activity.widgets import TitleEntry
 from sugar3.activity.widgets import StopButton
-from sugar3.activity.widgets import ShareButton
-from sugar3.activity.widgets import DescriptionItem
+from sugar3.activity.widgets import ActivityToolbarButton
 
 
 class HelloWorldActivity(activity.Activity):
@@ -45,21 +42,9 @@ class HelloWorldActivity(activity.Activity):
         # toolbar with the new toolbar redesign
         toolbar_box = ToolbarBox()
 
-        activity_button = ActivityButton(self)
+        activity_button = ActivityToolbarButton(self)
         toolbar_box.toolbar.insert(activity_button, 0)
         activity_button.show()
-
-        title_entry = TitleEntry(self)
-        toolbar_box.toolbar.insert(title_entry, -1)
-        title_entry.show()
-
-        description_item = DescriptionItem(self)
-        toolbar_box.toolbar.insert(description_item, -1)
-        description_item.show()
-
-        share_button = ShareButton(self)
-        toolbar_box.toolbar.insert(share_button, -1)
-        share_button.show()
 
         separator = Gtk.SeparatorToolItem()
         separator.props.draw = False

--- a/activity.py
+++ b/activity.py
@@ -16,6 +16,8 @@
 
 """HelloWorld Activity: A case study for developing an activity."""
 
+import gi
+gi.require_version('Gtk', '3.0')
 from gi.repository import Gtk
 import logging
 

--- a/activity.py
+++ b/activity.py
@@ -19,7 +19,6 @@
 import gi
 gi.require_version('Gtk', '3.0')
 from gi.repository import Gtk
-import logging
 
 from gettext import gettext as _
 
@@ -30,6 +29,7 @@ from sugar3.activity.widgets import TitleEntry
 from sugar3.activity.widgets import StopButton
 from sugar3.activity.widgets import ShareButton
 from sugar3.activity.widgets import DescriptionItem
+
 
 class HelloWorldActivity(activity.Activity):
     """HelloWorldActivity class as specified in activity.info"""
@@ -60,7 +60,7 @@ class HelloWorldActivity(activity.Activity):
         share_button = ShareButton(self)
         toolbar_box.toolbar.insert(share_button, -1)
         share_button.show()
-        
+
         separator = Gtk.SeparatorToolItem()
         separator.props.draw = False
         separator.set_expand(True)

--- a/activity/activity.info
+++ b/activity/activity.info
@@ -2,7 +2,7 @@
 name = HelloWorld
 activity_version = 6
 bundle_id = org.sugarlabs.HelloWorld
-exec = sugar-activity activity.HelloWorldActivity
+exec = sugar-activity3 activity.HelloWorldActivity
 icon = activity-helloworld
 license = GPLv2+
 repository = https://github.com/sugarlabs/hello-world-fork.git

--- a/activity/activity.info
+++ b/activity/activity.info
@@ -1,6 +1,6 @@
 [Activity]
 name = HelloWorld
-activity_version = 6
+activity_version = 7
 bundle_id = org.sugarlabs.HelloWorld
 exec = sugar-activity3 activity.HelloWorldActivity
 icon = activity-helloworld

--- a/activity/activity.info
+++ b/activity/activity.info
@@ -5,4 +5,4 @@ bundle_id = org.sugarlabs.HelloWorld
 exec = sugar-activity3 activity.HelloWorldActivity
 icon = activity-helloworld
 license = GPLv2+
-repository = https://github.com/sugarlabs/hello-world-fork.git
+repository = https://github.com/sugarlabs/hello-world.git

--- a/activity/activity.info
+++ b/activity/activity.info
@@ -5,3 +5,4 @@ bundle_id = org.sugarlabs.HelloWorld
 exec = sugar-activity activity.HelloWorldActivity
 icon = activity-helloworld
 license = GPLv2+
+repository = https://github.com/sugarlabs/hello-world-fork.git


### PR DESCRIPTION
When I tried to use the command **"flatpak-builder --user --force-clean --install build org.sugarlabs.HelloWorld.json"** to package the hello-world activity, there's an ModuleFoundError in **setup.py**. It seems that sugar3 no longer exists so I can't import bundlebuilder from sugar3.activity.